### PR TITLE
update go 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Scan source for Vulnerabilities (govulncheck)
         uses: golang/govulncheck-action@v1
-        with: 
+        with:
           go-package: -mode=source -show verbose ./src/
           repo-checkout: true
           # we need to set a version here until https://github.com/golang/go/issues/70036 is fixed..
-          go-version-input: 1.24.4
+          go-version-input: 1.24.6
           go-version-file: go.mod
   run_tests:
     name: Testbench

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,5 +14,5 @@ jobs:
           go-package: -mode=source -show verbose ./src/
           repo-checkout: true
           # we need to set a version here until https://github.com/golang/go/issues/70036 is fixed..
-          go-version-input: 1.24.4
+          go-version-input: 1.24.6
           go-version-file: go.mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.1.1] - In Progress
+
+### Changed
+- Update go to version 1.24.6 ([#32](https://github.com/united-security-providers/coraza-envoy-go-filter/issues/32)) ([daum3ns](https://github.com/daum3ns)) 
+
 ## [v1.1.0] - 2025-09-18
 
 ### Changed
@@ -37,5 +42,6 @@ _First release._
 ### Known Issues
 - - A bug in Coraza results in a wrong HTTP status code returned, if `SecResponseBodyLimit` is reached and `SecResponseBodyLimitAction` is set to `Reject`. Coraza incorrectly returns HTTP 413 instead of HTTP 500. ([corazawaf/coraza#1377](https://github.com/corazawaf/coraza/issues/1377))
 
+[v1.1.1]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.1.1
 [v1.1.0]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.1.0
 [v1.0.0]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module coraza-waf
 
 go 1.23.0
 
-toolchain go1.24.4
+toolchain go1.24.6
 
 require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443


### PR DESCRIPTION
closes #32 
fix https://pkg.go.dev/vuln/GO-2025-3849
