### PR TITLE
Publish docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           context: .
           target: envoy-coraza
+          build-args: BUILD_TAGS=coraza.rule.multiphase_evaluation
           push: true
           tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           context: .
           target: envoy-coraza
-          build-args: BUILD_TAGS=coraza.rule.multiphase_evaluation
           push: true
           tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,29 @@ jobs:
       - name: Generate Release Notes
         id: notes
         uses: theory/changelog-version-notes-action@v0.1.3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: envoy-coraza
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
       - name: Release Candidate
         uses: softprops/action-gh-release@v3
         if: ${{ contains(github.ref_name, '-rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           context: .
           target: envoy-coraza
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Release Candidate
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           context: .
           target: envoy-coraza
           push: true
-          tags: envoy-coraza:${{ github.ref_name }}
+          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Release Candidate
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           context: .
           target: envoy-coraza
           push: true
-          tags: ghcr.io/united-security-providers/coraza-envoy-go-filter/envoy-coraza:${{ github.ref_name }}
+          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Release Candidate
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           context: .
           target: envoy-coraza
           push: true
-          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
+          tags: ghcr.io/united-security-providers/coraza-envoy-go-filter/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Release Candidate
         uses: softprops/action-gh-release@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.0.0-rc1] - 2026-04-15
+## [v2.0.0-rc2] - 2026-04-15
 
 *The included configuration files and their paths have changed. Please consult the [updated README section](./README.md#using-crs) for details.*
 
@@ -113,7 +113,7 @@ _First release._
 - A bug in Coraza results in a wrong HTTP status code returned, if `SecResponseBodyLimit` is reached and `SecResponseBodyLimitAction` is set to `Reject`. Coraza incorrectly returns HTTP 413 instead of HTTP 500. ([corazawaf/coraza#1377](https://github.com/corazawaf/coraza/issues/1377))
 
 - 
-[v2.0.0-rc1]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v2.0.0-rc1
+[v2.0.0-rc2]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v2.0.0-rc2
 [v1.3.0]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.3.0
 [v1.2.3]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.2.3
 [v1.2.2]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.0.0] - 2026-XX-XX
+## [v2.0.0-rc3] - 2026-04-16
 
 *The included configuration files and their paths have changed. Please consult the [updated README section](./README.md#using-crs) for details.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.0.0-rc3] - 2026-04-16
+## [v2.0.0] - 2026-XX-XX
 
 *The included configuration files and their paths have changed. Please consult the [updated README section](./README.md#using-crs) for details.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - **Breaking:** Add support for "lts" and "latest" versions of CRS ([#81](https://github.com/united-security-providers/coraza-envoy-go-filter/pull/80))([daum3ns](https://github.com/daum3ns))
+- Build and publish docker image. Describe usage in EnvoyGateway ([#91](https://github.com/united-security-providers/coraza-envoy-go-filter/pull/91))([daum3ns](https://github.com/daum3ns))
 
 ### Changed
 - Update CRS to version 4.25 ([#81](https://github.com/united-security-providers/coraza-envoy-go-filter/pull/80))([daum3ns](https://github.com/daum3ns))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.0.0-rc2] - 2026-04-15
+## [v2.0.0] - 2026-XX-XX
 
 *The included configuration files and their paths have changed. Please consult the [updated README section](./README.md#using-crs) for details.*
 
@@ -113,7 +113,7 @@ _First release._
 - A bug in Coraza results in a wrong HTTP status code returned, if `SecResponseBodyLimit` is reached and `SecResponseBodyLimitAction` is set to `Reject`. Coraza incorrectly returns HTTP 413 instead of HTTP 500. ([corazawaf/coraza#1377](https://github.com/corazawaf/coraza/issues/1377))
 
 - 
-[v2.0.0-rc2]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v2.0.0-rc2
+[v2.0.0]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v2.0.0
 [v1.3.0]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.3.0
 [v1.2.3]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.2.3
 [v1.2.2]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.0.0] - 2026-XX-XX
+## [v2.0.0-rc1] - 2026-04-15
 
 *The included configuration files and their paths have changed. Please consult the [updated README section](./README.md#using-crs) for details.*
 
@@ -112,6 +112,8 @@ _First release._
 ### Known Issues
 - A bug in Coraza results in a wrong HTTP status code returned, if `SecResponseBodyLimit` is reached and `SecResponseBodyLimitAction` is set to `Reject`. Coraza incorrectly returns HTTP 413 instead of HTTP 500. ([corazawaf/coraza#1377](https://github.com/corazawaf/coraza/issues/1377))
 
+- 
+[v2.0.0-rc1]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v2.0.0-rc1
 [v1.3.0]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.3.0
 [v1.2.3]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.2.3
 [v1.2.2]: https://github.com/united-security-providers/coraza-envoy-go-filter/releases/tag/v1.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM envoyproxy/envoy:contrib-v1.37.2 AS envoy
+ARG BUILD_TAGS=coraza.rule.multiphase_evaluation
 
+FROM envoyproxy/envoy:contrib-v1.37.2 AS envoy
 ARG BUILD_TAGS
 
 RUN apt update && apt install -y libtool autoconf make libre2-dev curl tar python3 g++
@@ -11,6 +12,8 @@ RUN mkdir /libinjection && \
     make install
 
 FROM envoy AS build
+ARG BUILD_TAGS
+
 RUN apt update && apt install -y golang-1.23-go
 WORKDIR /src
 COPY internal ./internal

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ ENTRYPOINT ["/usr/bin/cp", "/src/coraza-waf.so", "/build"]
 FROM envoyproxy/envoy:contrib-v1.37.2 AS envoy-coraza
 COPY --from=build /usr/local/lib/libinjection.so* /usr/local/lib/
 COPY --from=build /src/coraza-waf.so /etc/envoy/coraza-waf.so
+COPY ./example/envoy.docker.yaml /etc/envoy/envoy.yaml
 RUN apt update && apt install -y libre2-9

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ performanceBuild:
 
 # Build the envoy image that we are going to use for tests and examples
 buildTestEnvoy:
-	docker build --target envoy --build-arg BUILD_TAGS=$(BUILD-TAGS) . -t coraza-waf-envoy
+	docker build --target envoy . -t coraza-waf-envoy
 
 start-watcher: clean build buildTestEnvoy
 	docker compose down

--- a/README.md
+++ b/README.md
@@ -2,55 +2,6 @@
 
 * [Coraza](https://github.com/corazawaf/coraza) Web Application Firewall implemented as Envoy Go Filter.
 
-## Compilation
-
-See [Makefile](./Makefile) for all targets.
-
-### Building the filter
-
-```bash
-make build
-# or
-make performanceBuild
-```
-
-You will find the go waf plugin under `./build/coraza-waf.so`.
-
-### Performance
-
-There is [a known performance issue with larger request bodies in Coraza](https://github.com/corazawaf/coraza/issues/1176).
-To help mitigate this, a new build target named `performanceBuild` has been introduced.
-This target compiles the filter with support for both [re2](https://github.com/google/re2) and
-[libinjection](https://github.com/libinjection/libinjection) to improve throughput.
-The only downside is that this build introduces runtime dependencies on `re2` and `libinjection`.
-
-You can enable this behavior through the configuration. For example:
-
-```yaml
-  ...
-
-  filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          stat_prefix: ingress_http
-          http_filters:
-            - name: envoy.filters.http.golang
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
-                library_id: coraza-waf
-                library_path: /etc/envoy/coraza-waf.so
-                plugin_name: coraza-waf
-                plugin_config:
-                  "@type": type.googleapis.com/xds.type.v3.TypedStruct
-                  value:
-                    use_re2: true
-                    use_libinjection: true
-```
-
-Setting these configuration options in the normal build will have no effect on coraza.
-
 ## Getting started
 
 ### Running the docker image
@@ -278,6 +229,55 @@ If you want to run the ftw test suite, the configuration files are included in t
 * [@coraza-ftw-lts](./internal/config/coreruleset/lts/coraza-ftw.conf): configures coraza for ftw tests
 * [@crs-ftw-latest](./internal/config/coreruleset/lts/crs-ftw.conf): configures latest rule engine for ftw tests
 * [@coraza-ftw-latest](./internal/config/coreruleset/latest/coraza-ftw.conf): configures coraza for ftw tests
+
+## Compilation
+
+See [Makefile](./Makefile) for all targets.
+
+### Building the filter
+
+```bash
+make build
+# or
+make performanceBuild
+```
+
+You will find the go waf plugin under `./build/coraza-waf.so`.
+
+### Performance
+
+There is [a known performance issue with larger request bodies in Coraza](https://github.com/corazawaf/coraza/issues/1176).
+To help mitigate this, a new build target named `performanceBuild` has been introduced.
+This target compiles the filter with support for both [re2](https://github.com/google/re2) and
+[libinjection](https://github.com/libinjection/libinjection) to improve throughput.
+The only downside is that this build introduces runtime dependencies on `re2` and `libinjection`.
+
+You can enable this behavior through the configuration. For example:
+
+```yaml
+  ...
+
+  filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          http_filters:
+            - name: envoy.filters.http.golang
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
+                library_id: coraza-waf
+                library_path: /etc/envoy/coraza-waf.so
+                plugin_name: coraza-waf
+                plugin_config:
+                  "@type": type.googleapis.com/xds.type.v3.TypedStruct
+                  value:
+                    use_re2: true
+                    use_libinjection: true
+```
+
+Setting these configuration options in the normal build will have no effect on coraza.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * [Coraza](https://github.com/corazawaf/coraza) Web Application Firewall implemented as Envoy Go Filter.
 
-## Getting started
+## Compilation
 
 See [Makefile](./Makefile) for all targets.
 
@@ -51,6 +51,15 @@ You can enable this behavior through the configuration. For example:
 
 Setting these configuration options in the normal build will have no effect on coraza.
 
+## Getting started
+
+### Running the docker image
+
+```bash
+docker pull ghcr.io/united-security-providers/envoy-coraza:v2.0.0
+docker run -p 8080:10000 -v ./<path_to_local_envoy.yaml>:/etc/envoy/envoy.yaml ghcr.io/united-security-providers/envoy-coraza:v2.0.0
+```
+
 ### Running the filter in an Envoy process
 
 In order to run the coraza go filter, we need to spin up an envoy configuration including this as the filter config
@@ -87,22 +96,123 @@ In order to run the coraza go filter, we need to spin up an envoy configuration 
                                               "Include @owasp_crs_lts/*.conf",
                                               "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
                                           ]
+                                    },
+                                    "off":{
+                                      "simple_directives":[
+                                        "SecRuleEngine Off"
+                                      ]
                                     }
                                 }
                         default_directive: "waf1"
                         host_directive_map: |
                           {
                             "foo.example.com":"waf1",
-                            "bar.example.com":"waf1"
+                            "bar.example.com":"off"
                           }
+```
+
+### Using with EnvoyGateway
+
+Enable [EnvoyPatchPolicy](https://gateway.envoyproxy.io/docs/tasks/extensibility/envoy-patch-policy/#enable-envoypatchpolicy)
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-gateway-config
+  namespace: envoy-gateway-system
+data:
+  envoy-gateway.yaml: |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: EnvoyGateway
+    provider:
+      type: Kubernetes
+    gateway:
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    extensionApis:
+      enableEnvoyPatchPolicy: true
+```
+
+Update the EnvoyProxy to use the united-security-providers/envoy-coraza image:
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: eg
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          image: ghcr.io/united-security-providers/envoy-coraza:v2.0.0
+```
+
+Enable the plugin with an EnvoyPatchPolicy:
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyPatchPolicy
+metadata:
+  name: coraza-patch-policy
+  namespace: envoy-gateway-system
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: eg-internal
+  type: JSONPatch
+  jsonPatches:
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    ## The name is in the format <namespace>/<gateway>/<listener> as per the XDS Name Scheme V2 - https://gateway.envoyproxy.io/docs/tasks/extensibility/envoy-patch-policy/#xds-name-scheme-v2
+    name: envoy-gateway-system/eg/https
+    operation:
+      op: add
+      ## Needs to be added as the first item in the 'http_filters' array
+      path: "/filter_chains/0/filters/0/typed_config/http_filters/0"
+      value:
+        name: envoy.filters.http.golang
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
+          library_id: coraza-waf
+          library_path: /etc/envoy/coraza-waf.so
+          plugin_name: coraza-waf
+          plugin_config:
+            "@type": type.googleapis.com/xds.type.v3.TypedStruct
+            value:
+              ## setting the logs to json format, so they are the same as the default EnvoyGateway Access Logs
+              log_format: "json"
+              ## configure coraza/CRS
+              directives: |
+                {
+                  "default":{
+                    "simple_directives":[
+                      "Include @coraza-lts",
+                      "SecDebugLogLevel 9",
+                      "SecRuleEngine On",
+                      "Include @crs-setup-lts",
+                      "Include @owasp_crs_lts/*.conf"
+                    ]
+                  },
+                  "off":{
+                    "simple_directives":[
+                      "SecRuleEngine Off"
+                    ]
+                  }
+                }
+              default_directive: "default"
+              host_directive_map: |
+                {
+                  "foo.example.com":"off",
+                  "bar.example.com":"default"
+                }
 ```
 
 ### Using CRS
 
 Two versions of the [Core Rule Set](https://github.com/coreruleset/coreruleset) come embedded in the extension.
 
-* LTS: long term supported CRS version 
-* latest: the latest CRS version
+* LTS: long term supported CRS version [@owasp_crs_lts/*.conf](./internal/config/coreruleset/lts/rules)
+* latest: the latest CRS version  [@owasp_crs_latest/*.conf](./internal/config/coreruleset/latest/rules)
 
 This allows to update the filter without the need to also update the CRS by staying on the "lts" version. This can be handy in sophisticated setups with a lot of rule exclusions, where switching the CRS version means a lot of migration effort. 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker pull ghcr.io/united-security-providers/envoy-coraza:v2.0.0
 docker run -p 8080:10000 ghcr.io/united-security-providers/envoy-coraza:v2.0.0
 ```
 
-Then visit http://localhost:8080 and then http://localhost:8080/alert('xss'). The second request should be blocked and you should see `WAF rule triggered: Javascript method detected` in the container logs.
+First visit http://localhost:8080 and then http://localhost:8080/alert('xss'). The second request should be blocked and you should see `WAF rule triggered: Javascript method detected` in the container logs.
 
 ### Running the filter in an Envoy process
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@
 
 ### Running the docker image
 
+Pull and start the image:
 ```bash
 docker pull ghcr.io/united-security-providers/envoy-coraza:v2.0.0
-docker run -p 8080:10000 -v ./<path_to_local_envoy.yaml>:/etc/envoy/envoy.yaml ghcr.io/united-security-providers/envoy-coraza:v2.0.0
+docker run -p 8080:10000 ghcr.io/united-security-providers/envoy-coraza:v2.0.0
 ```
+
+Then visit http://localhost:8080 and then http://localhost:8080/alert('xss'). The second request should be blocked and you should see `WAF rule triggered: Javascript method detected` in the container logs.
 
 ### Running the filter in an Envoy process
 

--- a/example/envoy.docker.yaml
+++ b/example/envoy.docker.yaml
@@ -47,10 +47,6 @@ static_resources:
                             "simple_directives":[
                                   "Include @coraza-lts",
                                   "Include @crs-setup-lts",
-                                  "SecDefaultAction \"phase:3,log,auditlog,pass\"",
-                                  "SecDefaultAction \"phase:4,log,auditlog,pass\"",
-                                  "SecDefaultAction \"phase:5,log,auditlog,pass\"",
-                                  "SecDebugLogLevel 3",
                                   "Include @owasp_crs_lts/*.conf"
                             ]
                         }

--- a/example/envoy.docker.yaml
+++ b/example/envoy.docker.yaml
@@ -1,0 +1,82 @@
+admin:
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 9901
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          scheme_header_transformation:
+            scheme_to_overwrite: https
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  host_rewrite_literal: www.envoyproxy.io
+                  cluster: service_envoyproxy_io
+          http_filters:
+          - name: envoy.filters.http.golang
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
+              library_id: coraza-waf
+              library_path: /etc/envoy/coraza-waf.so
+              plugin_name: coraza-waf
+              plugin_config:
+                "@type": type.googleapis.com/xds.type.v3.TypedStruct
+                value:
+                  directives: |
+                    {
+                      "waf1":{
+                            "simple_directives":[
+                                  "Include @coraza-lts",
+                                  "Include @crs-setup-lts",
+                                  "SecDefaultAction \"phase:3,log,auditlog,pass\"",
+                                  "SecDefaultAction \"phase:4,log,auditlog,pass\"",
+                                  "SecDefaultAction \"phase:5,log,auditlog,pass\"",
+                                  "SecDebugLogLevel 3",
+                                  "Include @owasp_crs_lts/*.conf"
+                            ]
+                        }
+                    }
+                  default_directive: "waf1"
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: service_envoyproxy_io
+    connect_timeout: 30s
+    type: LOGICAL_DNS
+    # Comment out the following line to test on v6 networks
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: service_envoyproxy_io
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: www.envoyproxy.io
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: www.envoyproxy.io


### PR DESCRIPTION
adds building and publishing the docker image to the release workflow.
updated readme on how to use with envoy gateway and patchpolicy

Closes #58 
Closes #84 

parts thankfully taken from this fork https://github.com/aaronspruit/coraza-envoy-go-filter-image 🙏🏾 
