### PR TITLE
feat(docker): Add ARM64 support to Docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,15 @@ jobs:
           # we need to set a version here until https://github.com/golang/go/issues/70036 is fixed..
           go-version-input: ""
           go-version-file: go.mod
+  build_arm64:
+    name: Build (ARM64)
+    if: ${{ github.ref_type != 'tag' }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Build ARM64 image
+        run: make performanceBuildImage
   run_tests:
     name: Testbench
     if: ${{ github.ref_type != 'tag' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,19 +18,18 @@ jobs:
           # we need to set a version here until https://github.com/golang/go/issues/70036 is fixed..
           go-version-input: ""
           go-version-file: go.mod
-  build_arm64:
-    name: Build (ARM64)
-    if: ${{ github.ref_type != 'tag' }}
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-      - name: Build ARM64 image
-        run: make performanceBuildImage
   run_tests:
-    name: Testbench
+    name: Testbench (${{ matrix.arch }})
     if: ${{ github.ref_type != 'tag' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -46,6 +50,18 @@ jobs:
         with:
           context: .
           target: envoy-coraza
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/united-security-providers/envoy-coraza:perf-${{ github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_TAGS=coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: envoy-coraza
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,21 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
-      - name: Build and push Docker image
+          images: ghcr.io/${{ github.repository_owner }}/envoy-coraza
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build and push performance Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           target: envoy-coraza
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}-perf
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/envoy-coraza:${{ github.ref_name }}-perf
+            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_TAGS=coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo
@@ -59,9 +65,22 @@ jobs:
           target: envoy-coraza
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/envoy-coraza:${{ github.ref_name }}
+            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Final Release
+      - name: Deploy Release Candidate
+        uses: softprops/action-gh-release@v3
+        if: ${{ contains(github.ref_name, '-rc') }}
+        with:
+          body_path: '${{ steps.notes.outputs.file }}'
+          generate_release_notes: false
+          prerelease: true
+          files: |
+            CHANGELOG.md
+            LICENSE
+            build/coraza-waf.so
+      - name: Deploy Final Release
         uses: softprops/action-gh-release@v3
         if: ${{ !contains(github.ref_name, '-') }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,16 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/envoy-coraza
+
 jobs:
-  build:
-    name: Build and Deploy
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -26,10 +25,29 @@ jobs:
         run: make ftw
       - name: Run e2e tests
         run: make e2e
-      - name: Generate Release Notes
-        id: notes
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: theory/changelog-version-notes-action@v0.1.3
+
+  build:
+    name: Build (${{ matrix.variant }}/${{ matrix.arch }})
+    needs: test
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [standard, performance]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            os: ubuntu-latest
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -40,46 +58,123 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/envoy-coraza
+          images: ${{ env.IMAGE }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: envoy-coraza
+          platforms: linux/${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_TAGS=${{ matrix.variant == 'performance' && 'coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo' || 'coraza.rule.multiphase_evaluation' }}
+          outputs: |
+            type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+            type=local,dest=${{ runner.temp }}/rootfs
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.variant }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      - name: Stage shared object
+        run: |
+          suffix=${{ matrix.variant == 'performance' && '-perf' || '' }}
+          mkdir -p "${{ runner.temp }}/so"
+          cp "${{ runner.temp }}/rootfs/etc/envoy/coraza-waf.so" \
+            "${{ runner.temp }}/so/coraza-waf${suffix}-${{ matrix.arch }}.so"
+      - name: Upload shared object
+        uses: actions/upload-artifact@v4
+        with:
+          name: coraza-waf-so-${{ matrix.variant }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/so/*.so
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest (${{ matrix.variant }})
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [standard, performance]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.variant }}-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: |
+            latest=false
+            suffix=${{ matrix.variant == 'performance' && '-perf' || '' }}
           tags: |
+            type=raw,value=${{ github.ref_name }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - name: Build and push performance Docker image
-        uses: docker/build-push-action@v7
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+
+  release:
+    name: Deploy Release
+    needs: merge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Download shared objects
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          target: envoy-coraza
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/envoy-coraza:${{ github.ref_name }}-perf
-            ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_TAGS=coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: envoy-coraza
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/envoy-coraza:${{ github.ref_name }}
-            ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          path: build
+          pattern: coraza-waf-so-*
+          merge-multiple: true
+      - name: Generate Release Notes
+        id: notes
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: theory/changelog-version-notes-action@v0.1.3
       - name: Deploy Release Candidate
         uses: softprops/action-gh-release@v3
-        if: ${{ contains(github.ref_name, '-rc') }}
+        if: ${{ contains(github.ref_name, '-') }}
         with:
-          body_path: '${{ steps.notes.outputs.file }}'
-          generate_release_notes: false
+          generate_release_notes: true
           prerelease: true
           files: |
             CHANGELOG.md
             LICENSE
-            build/coraza-waf.so
+            build/*.so
       - name: Deploy Final Release
         uses: softprops/action-gh-release@v3
         if: ${{ !contains(github.ref_name, '-') }}
@@ -90,14 +185,4 @@ jobs:
           files: |
             CHANGELOG.md
             LICENSE
-            build/coraza-waf.so
-      - name: Pre-release
-        uses: softprops/action-gh-release@v3
-        if: ${{ contains(github.ref_name, '-') }}
-        with:
-          generate_release_notes: true
-          prerelease: true
-          files: |
-            CHANGELOG.md
-            LICENSE
-            build/coraza-waf.so
+            build/*.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,6 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
@@ -52,7 +48,7 @@ jobs:
           target: envoy-coraza
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/united-security-providers/envoy-coraza:perf-${{ github.ref_name }}
+          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}-perf
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_TAGS=coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,6 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
@@ -51,7 +47,7 @@ jobs:
           target: envoy-coraza
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/united-security-providers/envoy-coraza:perf-${{ github.ref_name }}
+          tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}-perf
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_TAGS=coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -45,6 +49,18 @@ jobs:
         with:
           context: .
           target: envoy-coraza
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/united-security-providers/envoy-coraza:perf-${{ github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_TAGS=coraza.rule.multiphase_evaluation,libinjection_cgo,re2_cgo
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: envoy-coraza
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/united-security-providers/envoy-coraza:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,12 @@
 
 ## Build
 ```bash
-make build              # → build/coraza-waf.so  (buildmode=c-shared)
-make performanceBuild   # Docker CGO cross-compile with libinjection+re2
-make lint               # golangci-lint v2, all linters enabled, gofmt+goimports
-make start-watcher      # build → docker compose up → auto-restart on .so change
+make build                 # → build/coraza-waf.so  (buildmode=c-shared)
+make buildImage            # Envoy + filter in Docker
+make performanceBuild      # Docker CGO cross-compile with libinjection+re2
+make performanceBuildImage # Envoy + perf filter in Docker
+make lint                  # golangci-lint v2, all linters enabled, gofmt+goimports
+make start-watcher         # build → docker compose up → auto-restart on .so change
 ```
 
 ## Testing — no unit tests, only integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changed
-- Publish the Envoy Coraza image for both amd64 and arm64 platforms. ([#104](https://github.com/united-security-providers/coraza-envoy-go-filter/issues/104)) ([aslafy-z](https://github.com/aslafy-z))
+- Publish the Envoy Coraza image for both amd64 and arm64 platforms. ([#109](https://github.com/united-security-providers/coraza-envoy-go-filter/pull/109)) ([aslafy-z](https://github.com/aslafy-z))
 
 ## [v2.0.1] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Publish the Envoy Coraza image for both amd64 and arm64 platforms. ([#104](https://github.com/united-security-providers/coraza-envoy-go-filter/issues/104)) ([aslafy-z](https://github.com/aslafy-z))
 
 ## [v2.0.1] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Publish the Envoy Coraza image for both amd64 and arm64 platforms. ([#104](https://github.com/united-security-providers/coraza-envoy-go-filter/issues/104)) ([aslafy-z](https://github.com/aslafy-z))
 
 ## [v2.0.0] - 2026-05-19
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ performanceBuildImage:
 
 performanceBuild: performanceBuildImage
 	mkdir -p $(BUILD-DIRECTORY)
-	docker cp $$(docker create envoy-coraza-performance):/src/coraza-waf.so $(BUILD-DIRECTORY)
+	docker cp $$(docker create envoy-coraza-performance):/etc/envoy/coraza-waf.so $(BUILD-DIRECTORY)
 
 # Build the envoy image that we are going to use for tests and examples
 buildTestEnvoy:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ buildImage:
 	$(DOCKER_BUILDX_BUILD) --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS) . -t envoy-coraza
 
 performanceBuildImage:
-	$(DOCKER_BUILDX_BUILD) --target build --build-arg BUILD_TAGS=$(BUILD-TAGS),libinjection_cgo,re2_cgo . -t envoy-coraza-performance
+	$(DOCKER_BUILDX_BUILD) --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS),libinjection_cgo,re2_cgo . -t envoy-coraza-performance
 
 performanceBuild: performanceBuildImage
 	mkdir -p $(BUILD-DIRECTORY)

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ftw: clean build buildTestEnvoy
 clean:
 	docker compose down
 	docker compose --file tests/ftw/docker-compose.yml down
-	docker rmi -f coraza-waf-builder coraza-waf-envoy ftw-ftw-crs e2e-sse-server e2e-tests envoy-coraza
+	docker rmi -f coraza-waf-builder coraza-waf-envoy ftw-ftw-crs e2e-sse-server e2e-tests envoy-coraza envoy-coraza-performance
 	rm -rf $(BUILD-DIRECTORY)/*
 	go clean -testcache
 

--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,22 @@ BUILD-TAGS := coraza.rule.multiphase_evaluation
 GOLANG-CI-LINT-VERSION := v2.10.1
 BUILD-DIRECTORY := ./build
 
-PLATFORM ?= linux/$(shell go env GOARCH)
-DOCKER_BUILDX_BUILD := docker buildx build --platform $(PLATFORM) --load
-
 .PHONY: build
 build:
 	mkdir -p $(BUILD-DIRECTORY)
 	go build -o $(BUILD-DIRECTORY)/coraza-waf.so -buildmode=c-shared -tags=$(BUILD-TAGS)
 
 buildImage:
-	$(DOCKER_BUILDX_BUILD) --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS) . -t envoy-coraza
+	docker build --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS) . -t envoy-coraza
 
 performanceBuildImage:
-	$(DOCKER_BUILDX_BUILD) --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS),libinjection_cgo,re2_cgo . -t envoy-coraza-performance
+	docker build --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS),libinjection_cgo,re2_cgo . -t envoy-coraza-performance
 
 performanceBuild: performanceBuildImage
 	mkdir -p $(BUILD-DIRECTORY)
-	docker cp $$(docker create envoy-coraza-performance):/etc/envoy/coraza-waf.so $(BUILD-DIRECTORY)
+	docker_container=$$(docker create envoy-coraza-performance) && \
+	docker cp $$docker_container:/etc/envoy/coraza-waf.so $(BUILD-DIRECTORY) && \
+	docker rm $$docker_container
 
 # Build the envoy image that we are going to use for tests and examples
 buildTestEnvoy:

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,23 @@ BUILD-TAGS := coraza.rule.multiphase_evaluation
 GOLANG-CI-LINT-VERSION := v2.10.1
 BUILD-DIRECTORY := ./build
 
+PLATFORM ?= linux/$(shell go env GOARCH)
+DOCKER_BUILDX_BUILD := docker buildx build --platform $(PLATFORM) --load
+
 .PHONY: build
 build:
 	mkdir -p $(BUILD-DIRECTORY)
 	go build -o $(BUILD-DIRECTORY)/coraza-waf.so -buildmode=c-shared -tags=$(BUILD-TAGS)
 
-performanceBuild:
+buildImage:
+	$(DOCKER_BUILDX_BUILD) --target envoy-coraza --build-arg BUILD_TAGS=$(BUILD-TAGS) . -t envoy-coraza
+
+performanceBuildImage:
+	$(DOCKER_BUILDX_BUILD) --target build --build-arg BUILD_TAGS=$(BUILD-TAGS),libinjection_cgo,re2_cgo . -t envoy-coraza-performance
+
+performanceBuild: performanceBuildImage
 	mkdir -p $(BUILD-DIRECTORY)
-	docker build --target build --build-arg BUILD_TAGS=$(BUILD-TAGS),libinjection_cgo,re2_cgo . -t coraza-waf-builder
-	docker cp $$(docker create coraza-waf-builder):/src/coraza-waf.so $(BUILD-DIRECTORY)
+	docker cp $$(docker create envoy-coraza-performance):/etc/envoy/coraza-waf.so $(BUILD-DIRECTORY)
 
 # Build the envoy image that we are going to use for tests and examples
 buildTestEnvoy:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ performanceBuildImage:
 
 performanceBuild: performanceBuildImage
 	mkdir -p $(BUILD-DIRECTORY)
-	docker cp $$(docker create envoy-coraza-performance):/etc/envoy/coraza-waf.so $(BUILD-DIRECTORY)
+	docker cp $$(docker create envoy-coraza-performance):/src/coraza-waf.so $(BUILD-DIRECTORY)
 
 # Build the envoy image that we are going to use for tests and examples
 buildTestEnvoy:


### PR DESCRIPTION
## Summary

Build, test, and publish the Envoy Coraza images natively for both
`linux/amd64` and `linux/arm64`.

## What changed

### CI (`main.yml`)
The testbench (lint, build, FTW, e2e) runs as an `amd64`/`arm64` matrix on
native runners (`ubuntu-latest` and `ubuntu-24.04-arm`), so both architectures
are exercised on every pull request.

### Release (`release.yml`)
The release workflow is split into `test`, `build`, `merge`, and `release`
jobs:

- `build` runs a `{standard, performance} x {amd64, arm64}` matrix, each on its
  native runner. Each image is pushed to GHCR by digest, and the same build
  emits a local output from which the `coraza-waf.so` is extracted (no second
  build, no QEMU).
- `merge` combines the per-architecture digests into one multi-arch manifest
  per variant with `docker buildx imagetools create`, tagged with the release
  tag, semver tags, and the `-perf` suffix for the performance variant.
- `release` attaches the architecture-suffixed shared objects
  (`coraza-waf-{amd64,arm64}.so` and `coraza-waf-perf-{amd64,arm64}.so`) to the
  GitHub release.

### Makefile
- Add `buildImage` and `performanceBuildImage` targets using plain
  `docker build`.
- `performanceBuild` now extracts the `.so` from the `envoy-coraza-performance`
  image and removes the temporary container afterwards.
- `clean` removes the `envoy-coraza-performance` image.

### Docs
- `AGENTS.md` documents the new `buildImage` / `performanceBuildImage` targets.
- `CHANGELOG.md` records the multi-platform images.

## Motivation

Closes #104. Users on ARM64 hosts (Apple Silicon, Graviton, ...) can pull
native images, and releases ship native shared objects for both architectures.

## User-visible effects

- `envoy-coraza:<tag>` and `envoy-coraza:<tag>-perf` are published as
  multi-arch manifests covering `linux/amd64` and `linux/arm64`.
- The release no longer attaches a single `coraza-waf.so`. It now attaches four
  architecture-suffixed shared objects, two per variant.

## Test plan

- [x] `make buildImage` produces a local image for the host architecture.
- [x] `make performanceBuild` extracts the `.so` and removes the temp container.
- [x] Release workflow on a test tag pushes `linux/amd64` and `linux/arm64`
      manifests for both `envoy-coraza:<tag>` and `envoy-coraza:<tag>-perf`.
- [x] Release attaches all four `.so` assets.
- [x] Clean up test tags and artefacts.
