### PR TITLE
Fix EnvoyGateway deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ spec:
     operation:
       op: add
       ## Needs to be added as the first item in the 'http_filters' array
-      path: "/filter_chains/0/filters/0/typed_config/http_filters/0"
+      path: "/default_filter_chain/filters/0/typed_config/http_filters/0"
       value:
         name: envoy.filters.http.golang
         typed_config:
@@ -332,11 +332,10 @@ spec:
               directives:
                 default:
                   simple_directives:
-                    - "Include @coraza-lts"
                     - "SecDebugLogLevel 9"
                     - "SecRuleEngine On"
-                    - "Include @crs-setup-lts"
-                    - "Include @owasp_crs_lts/*.conf"
+                    - "Include @crs-setup"
+                    - "Include @owasp_crs/*.conf"
                 off:
                   simple_directives:
                     - "SecRuleEngine Off"

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ spec:
               directives:
                 default:
                   simple_directives:
+                    - "Include @coraza-setup"
                     - "SecDebugLogLevel 9"
                     - "SecRuleEngine On"
                     - "Include @crs-setup"


### PR DESCRIPTION
After spending some time trying to set this up on my local cluster I was only able to get the WAF running after making the following changes.

When using `path: "/filter_chains/0/filters/0/typed_config/http_filters/0"` I would get the following error:
```
Unable to unmarshal xds resource {...}, err:proto: (line 1:3682): missing "@type" field.
```

Can't say I am super familiar with these path types but I got the one in my change from [here](https://docs.openappsec.io/getting-started/start-with-kubernetes/integrate-with-envoy-gateway#envoypatchpolicy.yaml), and it works.

As far as the directives go, the ones in the current docs are not available using the default image without any configuration.
```
[2026-06-05 18:45:40.304][1][error][golang] [contrib/golang/common/log/cgo.cc:24] failed to parse golang plugin config: default mapping waf init error:invalid WAF config from string: failed to readfile: open @coraza-lts: file does not exist

[2026-06-05 18:46:02.279][1][error][golang] [contrib/golang/common/log/cgo.cc:24] failed to parse golang plugin config: default mapping waf init error:invalid WAF config from string: failed to readfile: open @crs-setup-lts: file does not exist
```
I pose this should be changed to just the non-lts owasp set so that the configuration works out of the box.