### PR TITLE
send location header with a redirect action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED] - UPCOMING
 
+### Added
+- Location header in redirect termination
+- e2e test for redirect termination
+
 ## [v3.0.0] - 2026-07-30
 
 ### Changed

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -383,11 +383,16 @@ func (f *Filter) handleInterruption(logger logging.Logger, phase phase, interrup
 		"status", interruption.Status,
 	)
 
+	headers := map[string][]string{}
+	if interruption.Action == "redirect" && interruption.Data != "" {
+		headers["Location"] = []string{interruption.Data}
+	}
+
 	switch phase {
 	case PhaseRequestHeader, PhaseRequestBody:
-		f.Callbacks.DecoderFilterCallbacks().SendLocalReply(interruption.Status, "", map[string][]string{}, 0, "")
+		f.Callbacks.DecoderFilterCallbacks().SendLocalReply(interruption.Status, "", headers, 0, "")
 	case PhaseResponseHeader, PhaseResponseBody:
-		f.Callbacks.EncoderFilterCallbacks().SendLocalReply(interruption.Status, "", map[string][]string{}, 0, "")
+		f.Callbacks.EncoderFilterCallbacks().SendLocalReply(interruption.Status, "", headers, 0, "")
 	}
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -460,3 +460,10 @@ func TestE2EFilesystemRuleOtherWafNotBlock(t *testing.T) {
 	checkRequest(t, "custom.example.com", envoyEndpoint+"/admin", http.MethodGet, http.StatusNotFound, false, "")
 	checkInLogs(t, http.StatusNotFound, http.MethodGet, "/admin")
 }
+
+func TestE2ERedirectLocationHeaderExpansion(t *testing.T) {
+	backendLogs.Reset()
+	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-redirect", http.MethodGet, http.StatusFound, true, "")
+	checkInLogs(t, http.StatusFound, http.MethodGet, "/test-redirect")
+}
+

--- a/tests/e2e/envoy.yaml
+++ b/tests/e2e/envoy.yaml
@@ -57,7 +57,19 @@ static_resources:
                                     - "SecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\""
                                     - "SecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\""
                                     - "SecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
-                                waf3:
+                                waf-redirect:
+                                  simple_directives:
+                                    - "Include @coraza-setup"
+                                    - "Include @crs-setup"
+                                    # - "SecRuleEngine On"
+                                    - "SecDefaultAction \"phase:1,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:2,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:3,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:4,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:5,log,auditlog,pass\""
+                                    - "SecDebugLogLevel 3"
+                                    - "Include @owasp_crs/*.conf"
+                                    - "SecRule REQUEST_URI \"@streq /test-redirect\" \"id:101,phase:1,t:none,redirect:/redirected/\""                                waf3:
                                   simple_directives:
                                     - "Include @coraza-setup"
                                     - "Include @crs-setup"
@@ -108,6 +120,7 @@ static_resources:
                                 "no-waf.example.com": "no-waf"
                                 "sse.example.com": "sse-response-body-off"
                                 "custom.example.com": "custom-rules"
+                                "redirect.example.com": "waf-redirect"
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/tests/e2e/envoy.yaml
+++ b/tests/e2e/envoy.yaml
@@ -61,7 +61,6 @@ static_resources:
                                   simple_directives:
                                     - "Include @coraza-setup"
                                     - "Include @crs-setup"
-                                    # - "SecRuleEngine On"
                                     - "SecDefaultAction \"phase:1,log,auditlog,pass\""
                                     - "SecDefaultAction \"phase:2,log,auditlog,pass\""
                                     - "SecDefaultAction \"phase:3,log,auditlog,pass\""

--- a/tests/e2e/envoy.yaml
+++ b/tests/e2e/envoy.yaml
@@ -57,18 +57,7 @@ static_resources:
                                     - "SecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\""
                                     - "SecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\""
                                     - "SecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
-                                waf-redirect:
-                                  simple_directives:
-                                    - "Include @coraza-setup"
-                                    - "Include @crs-setup"
-                                    - "SecDefaultAction \"phase:1,log,auditlog,pass\""
-                                    - "SecDefaultAction \"phase:2,log,auditlog,pass\""
-                                    - "SecDefaultAction \"phase:3,log,auditlog,pass\""
-                                    - "SecDefaultAction \"phase:4,log,auditlog,pass\""
-                                    - "SecDefaultAction \"phase:5,log,auditlog,pass\""
-                                    - "SecDebugLogLevel 3"
-                                    - "Include @owasp_crs/*.conf"
-                                    - "SecRule REQUEST_URI \"@streq /test-redirect\" \"id:101,phase:1,t:none,redirect:/redirected/\""                                waf3:
+                                waf3:
                                   simple_directives:
                                     - "Include @coraza-setup"
                                     - "Include @crs-setup"
@@ -82,6 +71,18 @@ static_resources:
                                     - "SecRequestBodyInMemoryLimit 40"
                                     - "SecRequestBodyLimit 40"
                                     - "SecRequestBodyLimitAction Reject"
+                                waf-redirect:
+                                  simple_directives:
+                                    - "Include @coraza-setup"
+                                    - "Include @crs-setup"
+                                    - "SecDefaultAction \"phase:1,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:2,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:3,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:4,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:5,log,auditlog,pass\""
+                                    - "SecDebugLogLevel 3"
+                                    - "Include @owasp_crs/*.conf"
+                                    - "SecRule REQUEST_URI \"@streq /test-redirect\" \"id:101,phase:1,t:none,redirect:/redirected/\""
                                 waf4:
                                   simple_directives:
                                     - "Include @coraza-setup"


### PR DESCRIPTION
Location header is missing when the secrule action is a redirect. This change checks if the interruption action is a redirect and has data, then include the location header.