### PR TITLE
add Location header in a redirect termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED] - UPCOMING
 
+### Added
+- Location header in redirect termination
+- e2e test for redirect termination
+
 ### Changed
 
 - Update libinjection to version 4.0.0 ([#148](https://github.com/united-security-providers/coraza-envoy-go-filter/pull/148)) ([kabbohus](https://github.com/kabbohus))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 - Location header in redirect termination
-- e2e test for redirect termination
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED] - UPCOMING
 
 ### Added
-- Location header in redirect termination with support of macro expansion
+- Send a Location header when a Coraza interruption uses the redirect action
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED] - UPCOMING
 
 ### Added
-- Location header in redirect termination
+- Location header in redirect termination with support of macro expansion
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED] - UPCOMING
 
 ### Added
-- Send a Location header when a Coraza interruption uses the redirect action
+- Send a Location header when a Coraza interruption uses the redirect action with macro expansion support ([#149](https://github.com/united-security-providers/coraza-envoy-go-filter/pull/149)) ([nevola](https://github.com/nevola))
 
 ### Changed
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -383,11 +383,16 @@ func (f *Filter) handleInterruption(logger logging.Logger, phase phase, interrup
 		"status", interruption.Status,
 	)
 
+	headers := map[string][]string{}
+	if interruption.Action == "redirect" && interruption.Data != "" {
+		headers["Location"] = []string{interruption.Data}
+	}
+
 	switch phase {
 	case PhaseRequestHeader, PhaseRequestBody:
-		f.Callbacks.DecoderFilterCallbacks().SendLocalReply(interruption.Status, "", map[string][]string{}, 0, "")
+		f.Callbacks.DecoderFilterCallbacks().SendLocalReply(interruption.Status, "", headers, 0, "")
 	case PhaseResponseHeader, PhaseResponseBody:
-		f.Callbacks.EncoderFilterCallbacks().SendLocalReply(interruption.Status, "", map[string][]string{}, 0, "")
+		f.Callbacks.EncoderFilterCallbacks().SendLocalReply(interruption.Status, "", headers, 0, "")
 	}
 }
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -12,10 +12,16 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 
+	"github.com/corazawaf/coraza/v3/collection"
+	"github.com/corazawaf/coraza/v3/debuglog"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/macro"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
+	"github.com/corazawaf/coraza/v3/types/variables"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 )
 
@@ -385,7 +391,17 @@ func (f *Filter) handleInterruption(logger logging.Logger, phase phase, interrup
 
 	headers := map[string][]string{}
 	if interruption.Action == "redirect" && interruption.Data != "" {
-		headers["Location"] = []string{interruption.Data}
+		location := interruption.Data
+		logger.Debug("Redirect macro expansion", "original", location, "action", interruption.Action)
+		if m, err := macro.NewMacro(location); err == nil {
+			txState := newTransactionStateAdapter(f.tx)
+			location = m.Expand(txState)
+			logger.Debug("Macro expansion result", "expanded", location)
+		} else {
+			logger.Debug("Failed to parse macro", "error", err)
+		}
+		headers["Location"] = []string{location}
+		logger.Debug("Setting Location header", "location", location)
 	}
 
 	switch phase {
@@ -410,3 +426,50 @@ func (f *Filter) splitHostPort(hostPortCombination string) (string, int, error) 
 
 	return ip, port, nil
 }
+
+type transactionStateAdapter struct {
+	tx                types.Transaction
+	collectionMethod  reflect.Value
+	interruptMethod   reflect.Value
+}
+
+func newTransactionStateAdapter(tx types.Transaction) *transactionStateAdapter {
+	adapter := &transactionStateAdapter{tx: tx}
+	txValue := reflect.ValueOf(tx)
+	adapter.collectionMethod = txValue.MethodByName("Collection")
+	adapter.interruptMethod = txValue.MethodByName("Interrupt")
+	return adapter
+}
+
+func (a *transactionStateAdapter) Collection(idx variables.RuleVariable) collection.Collection {
+	logger := a.tx.DebugLogger()
+	logger.Debug().Str("variable", idx.Name()).Msg("Collection lookup")
+	if a.collectionMethod.IsValid() {
+		results := a.collectionMethod.Call([]reflect.Value{reflect.ValueOf(idx)})
+		if len(results) > 0 && results[0].IsValid() {
+			if coll, ok := results[0].Interface().(collection.Collection); ok {
+				if single, ok := coll.(interface{ Get() string }); ok {
+					logger.Debug().Str("variable", idx.Name()).Str("value", single.Get()).Msg("Variable value")
+				}
+				return coll
+			}
+		}
+	}
+	logger.Debug().Str("variable", idx.Name()).Msg("Collection not found")
+	return nil
+}
+
+func (a *transactionStateAdapter) DebugLogger() debuglog.Logger {
+	return a.tx.DebugLogger()
+}
+
+func (a *transactionStateAdapter) ID() string                          { return a.tx.ID() }
+func (a *transactionStateAdapter) Variables() plugintypes.TransactionVariables { return nil }
+func (a *transactionStateAdapter) Interrupt(interruption *types.Interruption) {
+	if a.interruptMethod.IsValid() {
+		a.interruptMethod.Call([]reflect.Value{reflect.ValueOf(interruption)})
+	}
+}
+func (a *transactionStateAdapter) Capturing() bool               { return false }
+func (a *transactionStateAdapter) CaptureField(idx int, value string) {}
+func (a *transactionStateAdapter) LastPhase() types.RulePhase    { return 0 }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -12,16 +12,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/collection"
-	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/macro"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
-	"github.com/corazawaf/coraza/v3/types/variables"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 )
 
@@ -394,11 +390,10 @@ func (f *Filter) handleInterruption(logger logging.Logger, phase phase, interrup
 		location := interruption.Data
 		logger.Debug("Redirect macro expansion", "original", location, "action", interruption.Action)
 		if m, err := macro.NewMacro(location); err == nil {
-			txState := newTransactionStateAdapter(f.tx)
-			location = m.Expand(txState)
+			if ts, ok := f.tx.(plugintypes.TransactionState); ok {
+				location = m.Expand(ts)
+			}
 			logger.Debug("Macro expansion result", "expanded", location)
-		} else {
-			logger.Debug("Failed to parse macro", "error", err)
 		}
 		headers["Location"] = []string{location}
 		logger.Debug("Setting Location header", "location", location)
@@ -426,50 +421,3 @@ func (f *Filter) splitHostPort(hostPortCombination string) (string, int, error) 
 
 	return ip, port, nil
 }
-
-type transactionStateAdapter struct {
-	tx                types.Transaction
-	collectionMethod  reflect.Value
-	interruptMethod   reflect.Value
-}
-
-func newTransactionStateAdapter(tx types.Transaction) *transactionStateAdapter {
-	adapter := &transactionStateAdapter{tx: tx}
-	txValue := reflect.ValueOf(tx)
-	adapter.collectionMethod = txValue.MethodByName("Collection")
-	adapter.interruptMethod = txValue.MethodByName("Interrupt")
-	return adapter
-}
-
-func (a *transactionStateAdapter) Collection(idx variables.RuleVariable) collection.Collection {
-	logger := a.tx.DebugLogger()
-	logger.Debug().Str("variable", idx.Name()).Msg("Collection lookup")
-	if a.collectionMethod.IsValid() {
-		results := a.collectionMethod.Call([]reflect.Value{reflect.ValueOf(idx)})
-		if len(results) > 0 && results[0].IsValid() {
-			if coll, ok := results[0].Interface().(collection.Collection); ok {
-				if single, ok := coll.(interface{ Get() string }); ok {
-					logger.Debug().Str("variable", idx.Name()).Str("value", single.Get()).Msg("Variable value")
-				}
-				return coll
-			}
-		}
-	}
-	logger.Debug().Str("variable", idx.Name()).Msg("Collection not found")
-	return nil
-}
-
-func (a *transactionStateAdapter) DebugLogger() debuglog.Logger {
-	return a.tx.DebugLogger()
-}
-
-func (a *transactionStateAdapter) ID() string                          { return a.tx.ID() }
-func (a *transactionStateAdapter) Variables() plugintypes.TransactionVariables { return nil }
-func (a *transactionStateAdapter) Interrupt(interruption *types.Interruption) {
-	if a.interruptMethod.IsValid() {
-		a.interruptMethod.Call([]reflect.Value{reflect.ValueOf(interruption)})
-	}
-}
-func (a *transactionStateAdapter) Capturing() bool               { return false }
-func (a *transactionStateAdapter) CaptureField(idx int, value string) {}
-func (a *transactionStateAdapter) LastPhase() types.RulePhase    { return 0 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -466,4 +466,3 @@ func TestE2ERedirectLocationHeader(t *testing.T) {
 	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-redirect", http.MethodGet, http.StatusOK, false, "", "Referer", "http://172.17.0.1:32855/test-redirect")
 	checkInLogs(t, http.StatusOK, http.MethodGet, "/anything")
 }
-

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -460,3 +460,10 @@ func TestE2EFilesystemRuleOtherWafNotBlock(t *testing.T) {
 	checkRequest(t, "custom.example.com", envoyEndpoint+"/admin", http.MethodGet, http.StatusNotFound, false, "")
 	checkInLogs(t, http.StatusNotFound, http.MethodGet, "/admin")
 }
+
+func TestE2ERedirectLocationHeader(t *testing.T) {
+	backendLogs.Reset()
+	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-redirect", http.MethodGet, http.StatusOK, false, "", "Referer", "http://172.17.0.1:32855/test-redirect")
+	checkInLogs(t, http.StatusOK, http.MethodGet, "/anything")
+}
+

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -466,3 +466,9 @@ func TestE2ERedirectLocationHeader(t *testing.T) {
 	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-redirect", http.MethodGet, http.StatusOK, false, "", "Referer", "http://172.17.0.1:32855/test-redirect")
 	checkInLogs(t, http.StatusOK, http.MethodGet, "/anything")
 }
+
+func TestE2ERedirectLocationHeaderExpanded(t *testing.T) {
+	backendLogs.Reset()
+	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-expanded-redirect", http.MethodGet, http.StatusOK, false, "", "Referer", "http://172.17.0.1:32855/test-expanded-redirect")
+	checkInLogs(t, http.StatusOK, http.MethodGet, "/anything\\?uri=/test-expanded-redirect")
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -472,3 +472,9 @@ func TestE2ERedirectLocationHeaderExpanded(t *testing.T) {
 	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-expanded-redirect", http.MethodGet, http.StatusOK, false, "", "Referer", "http://172.17.0.1:32855/test-expanded-redirect")
 	checkInLogs(t, http.StatusOK, http.MethodGet, "/anything\\?uri=/test-expanded-redirect")
 }
+
+func TestE2ERedirectLocationHeaderWithStatus(t *testing.T) {
+	backendLogs.Reset()
+	checkRequest(t, "redirect.example.com", envoyEndpoint+"/test-redirect-with-status", http.MethodGet, http.StatusOK, false, "", "Referer", "http://172.17.0.1:32855/test-redirect-with-status")
+	checkInLogs(t, http.StatusOK, http.MethodGet, "/anything")
+}

--- a/tests/e2e/envoy.yaml
+++ b/tests/e2e/envoy.yaml
@@ -99,6 +99,14 @@ static_resources:
                                     - "SecRuleEngine On"
                                     - "Include /etc/envoy/custom_setup.conf"
                                     - "Include /etc/envoy/custom_rules/*.conf"
+                                redirect:
+                                  simple_directives:
+                                    - "Include @coraza-setup"
+                                    - "SecDefaultAction \"phase:3,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:4,log,auditlog,pass\""
+                                    - "SecDefaultAction \"phase:5,log,auditlog,pass\""
+                                    - "SecDebugLogLevel 3"
+                                    - "SecRule REQUEST_URI \"@streq /test-redirect\" \"id:101,phase:1,redirect:/anything\""
                               default_directive: "waf1"
                               host_directive_map:
                                 "foo.example.com": "waf1"
@@ -108,6 +116,7 @@ static_resources:
                                 "no-waf.example.com": "no-waf"
                                 "sse.example.com": "sse-response-body-off"
                                 "custom.example.com": "custom-rules"
+                                "redirect.example.com": "redirect"
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/tests/e2e/envoy.yaml
+++ b/tests/e2e/envoy.yaml
@@ -107,6 +107,7 @@ static_resources:
                                     - "SecDefaultAction \"phase:5,log,auditlog,pass\""
                                     - "SecDebugLogLevel 3"
                                     - "SecRule REQUEST_URI \"@streq /test-redirect\" \"id:101,phase:1,redirect:/anything\""
+                                    - "SecRule REQUEST_URI \"@streq /test-expanded-redirect\" \"id:102,phase:1,redirect:/anything?uri=%{REQUEST_URI}\""
                               default_directive: "waf1"
                               host_directive_map:
                                 "foo.example.com": "waf1"

--- a/tests/e2e/envoy.yaml
+++ b/tests/e2e/envoy.yaml
@@ -108,6 +108,7 @@ static_resources:
                                     - "SecDebugLogLevel 3"
                                     - "SecRule REQUEST_URI \"@streq /test-redirect\" \"id:101,phase:1,redirect:/anything\""
                                     - "SecRule REQUEST_URI \"@streq /test-expanded-redirect\" \"id:102,phase:1,redirect:/anything?uri=%{REQUEST_URI}\""
+                                    - "SecRule REQUEST_URI \"@streq /test-redirect-with-status\" \"id:103,phase:1,redirect:/anything,status:307\""
                               default_directive: "waf1"
                               host_directive_map:
                                 "foo.example.com": "waf1"


### PR DESCRIPTION
Location header is missing when the secrule action is a redirect. This change checks if the interruption action is a redirect and has data, then include the location header.

Also, updates changelog and adds an e2e test for this case.